### PR TITLE
feat(api): 여행지 공통 상세 정보 조회 구현

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOApiService.java
+++ b/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOApiService.java
@@ -1,6 +1,5 @@
 package com.traveloper.tourfinder.api.KTO.service;
 
-
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -17,16 +16,40 @@ public class KTOApiService {
     @Value("${kto.serviceKey}")
     private String serviceKey;
 
+    // 여행지 키워드 검색
     public Object getTripPlaces(
             String keyword
     ) {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
+        params.put("numOfRows", 12);
+        params.put("pageNo", 1);
         params.put("MobileOS", "ETC");
         params.put("MobileApp", "AppTest");
         params.put("_type", "json");
+        params.put("serviceKey", serviceKey);
+        params.put("listYN", "Y");
         params.put("arrange", "A");
         params.put("keyword", keyword);
-        params.put("serviceKey", serviceKey);
-        return ktoSearchService.localSearch(params);
+        return ktoSearchService.SearchKeyword(params);
     }
+
+
+    // 여행지 상세 정보 확인
+    public Object getPlaceDetails(
+            String contentId
+    ) {
+        Map<String, String> params = new HashMap<>();
+        params.put("serviceKey", serviceKey);
+        params.put("MobileOS", "ETC");
+        params.put("MobileApp", "AppTest");
+        params.put("_type", "json");
+        params.put("contentId", contentId);
+        params.put("defaultYN", "Y");
+        params.put("firstImageYN", "Y");
+        params.put("mapinfoYN", "Y");
+        params.put("overviewYN", "Y");
+        return ktoSearchService.DetailCommon(params);
+    }
+
+
 }

--- a/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOApiService.java
+++ b/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOApiService.java
@@ -33,7 +33,6 @@ public class KTOApiService {
         return ktoSearchService.SearchKeyword(params);
     }
 
-
     // 여행지 상세 정보 확인
     public Object getPlaceDetails(
             String contentId
@@ -50,6 +49,4 @@ public class KTOApiService {
         params.put("overviewYN", "Y");
         return ktoSearchService.DetailCommon(params);
     }
-
-
 }

--- a/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOSearchService.java
+++ b/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOSearchService.java
@@ -3,8 +3,14 @@ package com.traveloper.tourfinder.api.KTO.service;
 import java.util.Map;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
 
 public interface KTOSearchService {
+    // 키워드 검색
     @GetExchange("/B551011/KorService1/searchKeyword1")
-    Object localSearch(@RequestParam Map<String, String> params);
+    Object SearchKeyword(@RequestParam Map<String, Object> params);
+
+    // 공통 정보 조회
+    @GetExchange("/B551011/KorService1/detailCommon1")
+    Object DetailCommon(@RequestParam Map<String, String> params);
 }

--- a/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOSearchService.java
+++ b/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOSearchService.java
@@ -3,7 +3,6 @@ package com.traveloper.tourfinder.api.KTO.service;
 import java.util.Map;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
-import org.springframework.web.service.annotation.HttpExchange;
 
 public interface KTOSearchService {
     // 키워드 검색

--- a/src/main/java/com/traveloper/tourfinder/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/traveloper/tourfinder/common/config/WebSecurityConfig.java
@@ -28,7 +28,8 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "api/v1/auth/**",
-                                "api-test/**"
+                                "api-test/**",
+                                "api/v1/place"
                         )
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/swagger-ui/*")

--- a/src/main/java/com/traveloper/tourfinder/place/controller/TripPlaceController.java
+++ b/src/main/java/com/traveloper/tourfinder/place/controller/TripPlaceController.java
@@ -4,7 +4,6 @@ import com.traveloper.tourfinder.api.KTO.service.KTOApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,5 +31,4 @@ public class TripPlaceController {
     ) {
         return ktoApiService.getPlaceDetails(contentId);
     }
-
 }

--- a/src/main/java/com/traveloper/tourfinder/place/controller/TripPlaceController.java
+++ b/src/main/java/com/traveloper/tourfinder/place/controller/TripPlaceController.java
@@ -4,6 +4,7 @@ import com.traveloper.tourfinder.api.KTO.service.KTOApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,12 +16,21 @@ public class TripPlaceController {
     private final KTOApiService ktoApiService;
 
     // 관광정보 서비스 API 여행지 정보 검색
-    @GetMapping("/api-test/kto")
+    @GetMapping("/api-test/search")
     public Object searchPlaces(
             @RequestParam("keyword")
             String keyword
     ) {
         return ktoApiService.getTripPlaces(keyword);
+    }
+
+    // 관광정보 서비스 API 여행지 정보 검색
+    @GetMapping("/api-test/detail")
+    public Object placesDetails(
+            @RequestParam("contentId")
+            String contentId
+    ) {
+        return ktoApiService.getPlaceDetails(contentId);
     }
 
 }

--- a/src/main/java/com/traveloper/tourfinder/place/entity/TripPlace.java
+++ b/src/main/java/com/traveloper/tourfinder/place/entity/TripPlace.java
@@ -24,7 +24,6 @@ public class TripPlace extends BaseEntity {
     private String title;
     private String desc;
     private String thumbnailUrl;
-    private String naverPlaceId;
     private String phone;
     private String address;
     // mapx
@@ -32,4 +31,3 @@ public class TripPlace extends BaseEntity {
     // mapy
     private Double lat;
 }
-


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- trip-places

### 🔑 주요 변경사항
- 여행지 키워드 검색 부분 쿼리 파라미터 추가 (numOfRows, pageNo, listYN)
- `/api-test/search?keyword=키워드` URL 로 조회된 여행지 리스트에서, 특정 여행지의 `contentId` 의 값을 요청 파라미터로 추가
- 제목, 홈페이지 URL, 이미지, 위도, 경도, 여행지 개요 등이 JSON 형식으로 반환된다.

### 🏞 스크린샷
<img width="848" alt="image" src="https://github.com/like-lion-3team/trip/assets/110027583/b84582f2-4fcf-4d19-8b53-f183cb5429e6">

