### PR TITLE
chore(error): 에러 처리 중앙화

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
@@ -12,6 +12,8 @@ import com.traveloper.tourfinder.auth.jwt.JwtTokenUtils;
 import com.traveloper.tourfinder.auth.repo.MemberRepository;
 import com.traveloper.tourfinder.auth.repo.RoleRepository;
 import com.traveloper.tourfinder.common.RedisRepo;
+import com.traveloper.tourfinder.common.exception.CustomGlobalErrorCode;
+import com.traveloper.tourfinder.common.exception.GlobalExceptionHandler;
 import com.traveloper.tourfinder.common.util.RandomCodeUtils;
 import com.traveloper.tourfinder.course.service.CourseService;
 import jakarta.transaction.Transactional;
@@ -83,7 +85,7 @@ public class MemberService implements UserDetailsService {
     ) {
 
         Member member = memberRepository.findMemberByEmail(dto.getEmail()).orElseThrow(
-                () -> new EntityNotFoundException("로그인 실패")
+                () -> new GlobalExceptionHandler(CustomGlobalErrorCode.CREDENTIALS_NOT_MATCH)
         );
         // TODO: 로그인 - 비밀번호 검증
 

--- a/src/main/java/com/traveloper/tourfinder/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/traveloper/tourfinder/common/config/WebSecurityConfig.java
@@ -76,7 +76,7 @@ public class WebSecurityConfig {
                         new JwtTokenFilter(jwtTokenUtils, memberService),
                         AuthorizationFilter.class
                 ).addFilterBefore(
-                        new CustomJwtExceptionFilter(), UsernamePasswordAuthenticationFilter.class
+                        new CustomJwtExceptionFilter(jwtTokenUtils), UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/com/traveloper/tourfinder/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/traveloper/tourfinder/common/config/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package com.traveloper.tourfinder.common.config;
 import com.traveloper.tourfinder.auth.jwt.JwtTokenFilter;
 import com.traveloper.tourfinder.auth.jwt.JwtTokenUtils;
 import com.traveloper.tourfinder.auth.service.MemberService;
+import com.traveloper.tourfinder.common.exception.CustomJwtExceptionFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -73,6 +75,8 @@ public class WebSecurityConfig {
                 ).addFilterBefore(
                         new JwtTokenFilter(jwtTokenUtils, memberService),
                         AuthorizationFilter.class
+                ).addFilterBefore(
+                        new CustomJwtExceptionFilter(), UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/com/traveloper/tourfinder/common/exception/CustomGlobalErrorCode.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/CustomGlobalErrorCode.java
@@ -1,0 +1,23 @@
+package com.traveloper.tourfinder.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CustomGlobalErrorCode {
+
+    // 회원가입 에러
+    EMAIL_ALREADY_EXIST(409, "1001", "이미 가입된 이메일."),
+    NICKNAME_ALREADY_EXIST(409, "1002", "존재하는 닉네임."),
+    PASSWORD_VALIDATION_FAILED(400, "1003", "비밀번호 유효성 검증 실패."),
+
+    // 로그인 에러
+    CREDENTIALS_NOT_MATCH(401, "2001", "아이디 또는 비밀번호가 일치하지 않습니다."),
+    USER_BLOCKED(403, "2002", "차단된 사용자.");
+
+
+    private int status;
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/traveloper/tourfinder/common/exception/CustomGlobalErrorCode.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/CustomGlobalErrorCode.java
@@ -14,7 +14,16 @@ public enum CustomGlobalErrorCode {
 
     // 로그인 에러
     CREDENTIALS_NOT_MATCH(401, "2001", "아이디 또는 비밀번호가 일치하지 않습니다."),
-    USER_BLOCKED(403, "2002", "차단된 사용자.");
+    USER_BLOCKED(403, "2002", "차단된 사용자."),
+
+
+    // JWT 관련 에러
+    TOKEN_EXPIRED(401, "3001", "토큰이 만료되었습니다."),
+    UNSUPPORTED_TOKEN(400, "3002", "지원하지 않는 토큰입니다."),
+    MALFORMED_TOKEN(400, "3003", "잘못된 형식의 토큰입니다."),
+    SIGNATURE_INVALID(400, "3004", "토큰의 서명이 유효하지 않습니다."),
+    TOKEN_EMPTY(400, "3005", "토큰이 제공되지 않았습니다.");
+
 
 
     private int status;

--- a/src/main/java/com/traveloper/tourfinder/common/exception/CustomJwtExceptionFilter.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/CustomJwtExceptionFilter.java
@@ -1,5 +1,6 @@
 package com.traveloper.tourfinder.common.exception;
 
+import com.traveloper.tourfinder.auth.jwt.JwtTokenUtils;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -11,6 +12,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -18,13 +21,40 @@ import java.io.IOException;
 
 @Getter
 @AllArgsConstructor
+@Slf4j
 public class CustomJwtExceptionFilter extends OncePerRequestFilter {
-
+    private final JwtTokenUtils jwtTokenUtils;
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+
+
         try {
+                log.info("필터 시작");
+                String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+                if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                    log.info("토큰이 없거나 Bearer 타입이 아님");
+                    setErrorResponse(CustomGlobalErrorCode.MALFORMED_TOKEN, response);
+                    return;
+                }
+
+                String token = authHeader.substring(7); // "Bearer " 다음부터 토큰 추출
+                if (token.isEmpty()) {
+                    setErrorResponse(CustomGlobalErrorCode.TOKEN_EMPTY, response);
+                    return;
+                }
+
+                if (!jwtTokenUtils.validate(token)) {
+                    log.info("올바르지 않은 토큰");
+                    setErrorResponse(CustomGlobalErrorCode.MALFORMED_TOKEN, response);
+                    return;
+                }
+
             filterChain.doFilter(request, response);
-        } catch (ExpiredJwtException e) {
+        } catch (IllegalArgumentException e){
+            setErrorResponse(CustomGlobalErrorCode.TOKEN_EMPTY, response);
+        }
+        catch (ExpiredJwtException e) {
             setErrorResponse(CustomGlobalErrorCode.TOKEN_EXPIRED, response);
         } catch (UnsupportedJwtException e) {
             setErrorResponse(CustomGlobalErrorCode.UNSUPPORTED_TOKEN, response);
@@ -32,8 +62,6 @@ public class CustomJwtExceptionFilter extends OncePerRequestFilter {
             setErrorResponse(CustomGlobalErrorCode.MALFORMED_TOKEN, response);
         } catch (SignatureException e) {
             setErrorResponse(CustomGlobalErrorCode.SIGNATURE_INVALID, response);
-        } catch (IllegalArgumentException e) {
-            setErrorResponse(CustomGlobalErrorCode.TOKEN_EMPTY, response);
         } catch (JwtException e) {
             setErrorResponse(CustomGlobalErrorCode.TOKEN_EMPTY, response); // Or a general JWT error enum value
         }
@@ -41,12 +69,12 @@ public class CustomJwtExceptionFilter extends OncePerRequestFilter {
 
     private void setErrorResponse(CustomGlobalErrorCode error, HttpServletResponse response) throws IOException {
         response.setStatus(error.getStatus());
-        response.setContentType("application/json");
+        response.setContentType("application/json; charset=UTF-8");
         response.getWriter().write(convertToJson(error.getCode(), error.getMessage()));
     }
 
     private String convertToJson(String code, String message) {
-        return "{\"status\": \"" + code + "\", \"error\": \"" + message + "\"}";
+        return "{\"code\": \"" + code + "\", \"message\": \"" + message + "\"}";
     }
 }
 

--- a/src/main/java/com/traveloper/tourfinder/common/exception/CustomJwtExceptionFilter.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/CustomJwtExceptionFilter.java
@@ -1,0 +1,53 @@
+package com.traveloper.tourfinder.common.exception;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Getter
+@AllArgsConstructor
+public class CustomJwtExceptionFilter extends OncePerRequestFilter {
+
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(CustomGlobalErrorCode.TOKEN_EXPIRED, response);
+        } catch (UnsupportedJwtException e) {
+            setErrorResponse(CustomGlobalErrorCode.UNSUPPORTED_TOKEN, response);
+        } catch (MalformedJwtException e) {
+            setErrorResponse(CustomGlobalErrorCode.MALFORMED_TOKEN, response);
+        } catch (SignatureException e) {
+            setErrorResponse(CustomGlobalErrorCode.SIGNATURE_INVALID, response);
+        } catch (IllegalArgumentException e) {
+            setErrorResponse(CustomGlobalErrorCode.TOKEN_EMPTY, response);
+        } catch (JwtException e) {
+            setErrorResponse(CustomGlobalErrorCode.TOKEN_EMPTY, response); // Or a general JWT error enum value
+        }
+    }
+
+    private void setErrorResponse(CustomGlobalErrorCode error, HttpServletResponse response) throws IOException {
+        response.setStatus(error.getStatus());
+        response.setContentType("application/json");
+        response.getWriter().write(convertToJson(error.getCode(), error.getMessage()));
+    }
+
+    private String convertToJson(String code, String message) {
+        return "{\"status\": \"" + code + "\", \"error\": \"" + message + "\"}";
+    }
+}
+
+

--- a/src/main/java/com/traveloper/tourfinder/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/GlobalControllerAdvice.java
@@ -1,0 +1,35 @@
+package com.traveloper.tourfinder.common.exception;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 중앙 집중 예외처리를 위한 GlobalControllerAdvice 선언
+ * RestController를 사용중이니 Advice도 @RestControllerAdvice를 사용한다.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+
+    /**
+     * 에러 중앙처리 로직 작성완료
+     */
+    @ExceptionHandler(GlobalExceptionHandler.class)
+    public ResponseEntity<?> applicationHandler(GlobalExceptionHandler e) {
+        log.error("Error occurs {}", e.toString());
+
+        // 에러 응답을 세팅한다.
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("code", e.getCustomGlobalErrorCode().getCode());
+        errorResponse.put("message", e.getCustomGlobalErrorCode().getMessage());
+
+        return ResponseEntity.status(e.getCustomGlobalErrorCode().getStatus())
+                .body(errorResponse);
+    }
+
+}

--- a/src/main/java/com/traveloper/tourfinder/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.traveloper.tourfinder.common.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * <p>Controller 단에서 발생하는 모든 에러를 중앙에서 관리하기 위한 핸들러입니다. <br/>
+ * Filter 에서 발생한 에러는 Controller까지 전파되지 않으니 주의 해주세요.
+ * </p>
+ * */
+
+@Getter
+@AllArgsConstructor
+public class GlobalExceptionHandler extends RuntimeException{
+    private CustomGlobalErrorCode customGlobalErrorCode;
+}

--- a/src/main/java/com/traveloper/tourfinder/common/exception/GlobalRestControllerAdvice.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/GlobalRestControllerAdvice.java
@@ -13,7 +13,7 @@ import java.util.Map;
  */
 @Slf4j
 @RestControllerAdvice
-public class GlobalControllerAdvice {
+public class GlobalRestControllerAdvice {
 
 
     /**


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 💡 작업동기
- 서비스 내부에서 발생한 에러 종류를 클라이언트에게 알려주기 위함

### 🔑 주요 변경사항
- ```CustomGlobalErrorCode``` 공통 에러 코드 정의
- ```GlobalControllerAdvice``` Controller 단의 에러를 잡아내기 위한 클래스 정의
- ```GlobalExceptionHandler``` 에러 처리를 위한 핸들러
- ```CustomJwtExceptionFilter``` JWT 에러 처리를 위한 필터
- ```GlobalControllerAdvice``` -> ```GlobalRestControllerAdvice``` 파일이름 변경


**사용가이드**
에러를 발생시킬 곳에서 ```GlobalExceptionHandler``` 를 사용합니다.
```java
  Member member = memberRepository.findMemberByEmail(dto.getEmail()).orElseThrow(
                () -> new GlobalExceptionHandler(CustomGlobalErrorCode.CREDENTIALS_NOT_MATCH)
        );
```

```CustomGlobalErrorCode``` 파일에서 정의한 enum 값을 핸들러로 전달해주면 ```GlobalControllerAdvice``` 에서 클라이언트로 에러 정보가 담긴 응답을 보냅니다.

```CustomJwtExceptionFilter``` 에서는 GlobalExceptionHandler를 사용할 수 없어서 아래 예시 처럼 직접 응답 객체를 전송해야 합니다.

```java
 private void setErrorResponse(CustomGlobalErrorCode error, HttpServletResponse response) throws IOException {
        response.setStatus(error.getStatus());
        response.setContentType("application/json; charset=UTF-8");
        response.getWriter().write(convertToJson(error.getCode(), error.getMessage()));
    }

    private String convertToJson(String code, String message) {
        return "{\"code\": \"" + code + "\", \"message\": \"" + message + "\"}";
    }
```

