### PR TITLE
feat(course): sample-course-read 추가, 코스 더미 데이터 추가

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/traveloper/tourfinder/common/config/WebSecurityConfig.java
@@ -50,6 +50,7 @@ public class WebSecurityConfig {
                         .requestMatchers(
                                 "api/v1/auth/**",
                                 "api-test/**",
+                                "api/v1/courses",
                                 "api/v1/place",
                                 "api/v1/**",
 

--- a/src/main/java/com/traveloper/tourfinder/view/ViewController.java
+++ b/src/main/java/com/traveloper/tourfinder/view/ViewController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -41,16 +42,31 @@ public class ViewController {
         return "sample-course-list";
     }
 
+    @GetMapping("api-test/sample-course-read/{courseId}")
+    public String sampleCourseRead(
+            @PathVariable("courseId")
+            Long courseId,
+            Model model
+    ) {
+        model.addAttribute("clientId", NCP_CLIENT_ID);
+        model.addAttribute("courseId", courseId);
+        return "sample-course-read";
+    }
+
     @GetMapping("/login")
-    public String login(){
+    public String login() {
         return "login";
     }
 
     @GetMapping("/sign-up")
-    public String signUp() {return "signUp";}
+    public String signUp() {
+        return "signUp";
+    }
 
     @GetMapping("/my-page")
-    public String myPage() {return "my-page";}
+    public String myPage() {
+        return "my-page";
+    }
 
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -14,3 +14,10 @@ INSERT INTO Member(is_delete, role_id, email, member_name, nickname, password, u
 INSERT INTO Member(is_delete, role_id, email, member_name, nickname, password, uuid) VALUES (false, 3, 'jacobmaynard@holland.com', 'Kristina Tyler', 'susanrivas', '$2a$10$.f.TCAvMWWL2m5VV8GHxOOcJSjLkYW1CKA8E2EgA.rYxRCOeFQJ8a', 'e44c50ff-8043-4207-b827-c9c9e55db06d');
 INSERT INTO Member(is_delete, role_id, email, member_name, nickname, password, uuid) VALUES (false, 1, 'gallowaydaniel@jones.biz', 'Edward Ford', 'lopezjesse', '$2a$10$.f.TCAvMWWL2m5VV8GHxOOcJSjLkYW1CKA8E2EgA.rYxRCOeFQJ8a', 'cb8eb061-4ad6-465c-a0e5-65b5ab2bfa5b');
 INSERT INTO Member(is_delete, role_id, email, member_name, nickname, password, uuid) VALUES (false, 3, 'jjones@mcneil-brennan.com', 'Anthony Long', 'kbryant', '$2a$10$.f.TCAvMWWL2m5VV8GHxOOcJSjLkYW1CKA8E2EgA.rYxRCOeFQJ8a', '7e1c07d3-c538-4213-aa2e-45d1794017b7');
+
+INSERT INTO course (is_delete, title, desc, member_id) VALUES (false, '서울 코스', '서울 도는 코스 예시입니다.', 6);
+
+INSERT INTO place (is_delete, title, thumbnail_url, address, lng, lat, course_id)
+VALUES
+    (false, '광화문', 'http://tong.visitkorea.or.kr/cms/resource/72/3069472_image2_1.JPG', '서울특별시 종로구 사직로 161', 126.9768042386, 37.576072552, 1),
+    (false, '경복궁', 'http://tong.visitkorea.or.kr/cms/resource/33/2678633_image2_1.jpg', '서울특별시 종로구 사직로 161', 126.9769930325, 37.5788222356, 1);

--- a/src/main/resources/templates/sample-course-read.html
+++ b/src/main/resources/templates/sample-course-read.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>코스 조회</title>
+    <style>
+        /* 스타일링 */
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 20px auto;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 10px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+
+        .course-info {
+            margin-bottom: 20px;
+        }
+
+        .map-container {
+            display: flex;
+            align-items: flex-start;
+            margin-bottom: 20px;
+        }
+
+        #map {
+            flex: 1;
+            height: 400px; /* 지도의 높이 조절 */
+            border-radius: 5px;
+            overflow: hidden;
+        }
+
+        .place-list {
+            flex: 1;
+            margin-left: 20px;
+            cursor: pointer; /* 커서 모양을 포인터로 변경 */
+        }
+
+        .place-list ul {
+            list-style-type: none;
+            padding: 0;
+        }
+
+        .place-list ul li {
+            margin-bottom: 10px;
+            background-color: #f9f9f9;
+            padding: 10px;
+            border-radius: 5px;
+        }
+
+        .place-list ul li:hover {
+            background-color: #e0e0e0; /* 마우스를 올렸을 때 배경색 변경 */
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="course-info">
+        <h1 id="course-title">코스 제목</h1>
+        <p id="course-desc">코스 설명</p>
+    </div>
+
+    <div class="map-container">
+        <!-- 지도 -->
+        <div id="map">
+            <script type="text/javascript" th:src="@{https://openapi.map.naver.com/openapi/v3/maps.js(ncpClientId=${clientId})}"></script>
+        </div>
+        <div class="place-list" id="place-list">
+            <h2>장소 목록</h2>
+            <ul id="place-ul">
+                <!-- 장소 목록이 여기에 동적으로 추가됩니다 -->
+            </ul>
+        </div>
+    </div>
+</div>
+
+<script>
+    var mapOptions = {
+        center: new naver.maps.LatLng(37.3595704, 127.105399),
+        zoom: 15
+    };
+
+    var map = new naver.maps.Map('map', mapOptions);
+
+    // 코스 정보 설정
+    const courseTitle = document.getElementById('course-title');
+    const courseDesc = document.getElementById('course-desc');
+    const placeList = document.getElementById('place-ul');
+    var course;
+    var places;
+
+    function fetchCourseData() {
+        const courseId = [[${courseId}]];
+        fetch('/api/v1/courses/' + courseId)
+            .then(response => {
+                if (!response.ok) {
+                    // 응답이 성공적이지 않을 때 에러 처리
+                    throw new Error('API 요청이 실패했습니다.');
+                }
+                // JSON 형태로 변환하여 반환
+                return response.json();
+            })
+            .then(data => {
+                course = data;
+                places = data.places;
+                map.setCenter(new naver.maps.LatLng(places[0].lat, places[0].lng));
+                courseTitle.textContent = data.title;
+                courseDesc.textContent = data.desc;
+                data.places.forEach((place, index) => {
+                    const li = document.createElement('li');
+                    li.textContent = `${place.title}: ${place.address}`;
+                    li.addEventListener('click', () => {
+                        // 장소를 클릭하면 해당 위치로 지도 이동
+                        map.setCenter(new naver.maps.LatLng(place.lat, place.lng));
+                    });
+
+                    var marker = new naver.maps.Marker({
+                        position: new naver.maps.LatLng(place.lat, place.lng),
+                        map: map
+                    });
+
+                    placeList.appendChild(li);
+                })
+            })
+    }
+
+    fetchCourseData();
+
+    // TODO: 지도 표시 및 지도에 장소 마커 표시
+</script>
+</body>
+</html>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/course

### 🔑 주요 변경사항
- 만들어진 코스를 조회하는 페이지인 sample-course-read.html을 만들었습니다
- data.sql에 더미 course와 place를 삽입해두었습니다.
- http://localhost:8080/api-test/sample-course-read/1 에서 확인가능합니다.

### 🏞 스크린샷
![image](https://github.com/like-lion-3team/trip/assets/33568800/9e36584a-dcdd-4c9a-b293-c74c90f5ce30)
