### PR TITLE
feat(create-course): 선택한 여행지 리스트 표시 

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/course/controller/CourseController.java
+++ b/src/main/java/com/traveloper/tourfinder/course/controller/CourseController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/resources/static/css/sample-map.css
+++ b/src/main/resources/static/css/sample-map.css
@@ -9,23 +9,41 @@ body {
 
 /* 지도 스타일링 */
 #map {
-    width: calc(100% - 250px); /* 컨테이너 폭에서 사이드바 폭을 뺀 나머지를 지도 영역으로 설정합니다 */
+    width: calc(100% - 640px); /* 전체 폭에서 extra-content의 너비를 뺀 나머지를 가로 길이로 설정합니다. */
     height: 100vh;
     float: right; /* 오른쪽 정렬합니다 */
     position: relative; /* 모달이 지도 위에 나타날 수 있도록 */
+    z-index: 0;
 }
 
 
 .sidebar {
-    width: 400px;
+    width: 320px;
     height: 100vh;
     background-color: #f0f0f0;
     position: fixed;
     top: 0;
     left: 0;
+    transition: width 0.3s ease; /* 사이드바의 너비 변경 애니메이션 */
     overflow-y: auto;
     padding: 20px;
+    float: left;
+    z-index: 1; /* 다른 요소 위에 사이드바가 보이도록 z-index를 설정합니다 */
 }
+
+.extra-content {
+    position: fixed; /* 절대적으로 위치를 고정합니다. */
+    top: 0;
+    left: 360px; /* 사이드바의 너비만큼 왼쪽으로 이동하여 배치합니다. */
+    width: 280px; /* extra-content의 너비를 250px로 설정합니다. */
+    height: 100vh; /* 화면 높이에 맞게 설정합니다. */
+    padding: 20px; /* 내부 여백을 설정합니다. */
+    box-sizing: border-box; /* 내부 여백을 포함하여 크기를 계산합니다. */
+    background-color: #f0f0f0; /* 배경색을 설정합니다. */
+    z-index: 1; /* 다른 요소 위에 위치하도록 z-index를 설정합니다. */
+}
+
+
 
 .content {
     margin-left: 250px; /* 사이드바 너비 만큼 오른쪽으로 이동 */
@@ -53,6 +71,7 @@ body {
     font-size: 20px;
     color: #fff;
     cursor: pointer;
+    z-index: 2;
 }
 
 .close:hover {
@@ -61,7 +80,7 @@ body {
 
 /* 여행지 검색창 스타일링 */
 .search-container input[type="text"] {
-    width: 80%;
+    width: 75%;
     padding: 8px;
     border: 1px solid #ccc;
     border-radius: 5px;
@@ -107,4 +126,15 @@ body {
 }
 
 
-
+/* 코스 생성 버튼 스타일링 */
+#course-create-btn {
+    display: block;
+    margin-bottom: 10px;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    cursor: pointer;
+    width: 100%;
+    padding: 10px;
+    font-size: 16px;
+}

--- a/src/main/resources/static/css/sample-map.css
+++ b/src/main/resources/static/css/sample-map.css
@@ -132,6 +132,8 @@ body {
     display: block;
     margin-bottom: 10px;
     background-color: #4CAF50;
+    border-radius: 10px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     color: white;
     border: none;
     cursor: pointer;
@@ -178,19 +180,33 @@ body {
     color: #777;
 }
 
-#selected-places-list li button {
-    background-color: #4CAF50;
+#selected-places-list li button.remove-button {
+    background-color: #dc3545; /* btn-warning 색상 대신 빨간색 계열로 설정 */
     color: white;
     border: none;
-    padding: 10px 20px;
-    text-align: center;
-    text-decoration: none;
-    display: inline-block;
-    font-size: 16px;
-    border-radius: 5px;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    font-size: 12px;
     cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0;
+    margin-left: auto;
 }
 
-#selected-places-list li button:hover {
-    background-color: #45a049;
+#selected-places-list li {
+    margin-bottom: 10px;
+    background-color: #f9f9f9;
+    padding: 15px;
+    border-radius: 10px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    display: flex;
+    align-items: center;
 }
+
+#selected-places-list li .place-info {
+    flex: 1;
+}
+

--- a/src/main/resources/static/css/sample-map.css
+++ b/src/main/resources/static/css/sample-map.css
@@ -114,6 +114,7 @@ body {
 #places-list ul li {
     margin-bottom: 10px;
     background-color: #f9f9f9;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     padding: 10px;
     border-radius: 5px;
     position: relative; /* 부모 요소에 대해 상대적으로 위치를 지정합니다 */
@@ -139,4 +140,57 @@ body {
     font-size: 16px;
 }
 
+/* 선택한 여행지 스타일링 */
+#selected-places-list {
+    list-style-type: none;
+    padding: 0;
+}
 
+#selected-places-list li {
+    margin-bottom: 10px;
+    background-color: #f9f9f9;
+    padding: 15px;
+    border-radius: 10px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    display: flex;
+    align-items: center;
+}
+
+#selected-places-list li img {
+    width: 70px;
+    height: 70px;
+    border-radius: 50%;
+    margin-right: 15px;
+}
+
+#selected-places-list li .place-info {
+    flex: 1;
+}
+
+#selected-places-list li h4 {
+    margin: 0;
+    font-size: 18px;
+}
+
+#selected-places-list li p {
+    margin: 5px 0;
+    font-size: 14px;
+    color: #777;
+}
+
+#selected-places-list li button {
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+#selected-places-list li button:hover {
+    background-color: #45a049;
+}

--- a/src/main/resources/static/css/sample-map.css
+++ b/src/main/resources/static/css/sample-map.css
@@ -138,3 +138,5 @@ body {
     padding: 10px;
     font-size: 16px;
 }
+
+

--- a/src/main/resources/static/js/marker-places.js
+++ b/src/main/resources/static/js/marker-places.js
@@ -1,12 +1,15 @@
-// "코스에 추가" 버튼 클릭 시 호출되는 함수
-function addToCourse(contentId) {
-    // 추가되지 않은 경우 해당 여행지의 좌표를 가져와 마커를 표시하고 상태를 업데이트
-    getPlaceCoordinates(contentId);
+// 여행지를 저장할 배열 초기화
+let selectedPlaces = [];
+
+// 여행지를 선택하여 배열에 추가하는 함수
+function addPlace(place) {
+    // 선택한 여행지를 배열에 추가
+    selectedPlaces.push(place);
 }
 
-// 여행지의 좌표를 가져오는 함수
-function getPlaceCoordinates(contentId) {
-    // API 호출하여 여행지의 좌표값을 가져옵니다
+// "코스에 추가" 버튼 클릭 시 호출되는 함수
+function addToCourse(contentId) {
+    // API 호출하여 여행지의 정보 가져오기
     fetch(`/api-test/detail?contentId=${contentId}`)
         .then(response => {
             if (!response.ok) {
@@ -17,12 +20,21 @@ function getPlaceCoordinates(contentId) {
             return response.json();
         })
         .then(data => {
-            // API 응답 데이터에서 여행지의 좌표값을 가져와서 배열에 저장합니다
-            const places = data.response.body.items.item;
-            const coordinates = places.map(place => ({
-                mapx: parseFloat(place.mapx),
-                mapy: parseFloat(place.mapy)
-            }));
+            // 여행지의 정보를 가져와서 선택한 여행지 배열에 추가
+            const place = {
+                contentId: contentId,
+                title: data.response.body.items.item[0].title
+            };
+            addPlace(place);
+
+            // 선택한 여행지 목록을 화면에 표시
+            renderSelectedPlaces();
+
+            // 여행지 좌표를 가져와 지도에 마커 표시
+            const coordinates = [{
+                mapx: parseFloat(data.response.body.items.item[0].mapx),
+                mapy: parseFloat(data.response.body.items.item[0].mapy)
+            }];
             // 가져온 좌표값으로 마커를 표시합니다
             displayMarkers(coordinates);
         })
@@ -31,8 +43,23 @@ function getPlaceCoordinates(contentId) {
             alert(error.message);
             console.error('Error:', error);
         });
+
 }
 
+
+// 선택한 여행지를 화면에 표시하는 함수
+function renderSelectedPlaces() {
+    let selectedPlacesList = document.getElementById("selected-places-list");
+    // 기존에 표시되었던 여행지 목록 초기화
+    selectedPlacesList.innerHTML = "";
+
+    // 선택한 여행지 배열을 순회하면서 각각의 여행지를 화면에 추가
+    selectedPlaces.forEach(place => {
+        let listItem = document.createElement("li");
+        listItem.textContent = place.title; // 여행지 이름 등 필요한 정보를 여기서 표시
+        selectedPlacesList.appendChild(listItem);
+    });
+}
 
 // 여행지의 좌표를 지도에 마커로 표시하는 함수
 function displayMarkers(coordinates) {

--- a/src/main/resources/static/js/marker-places.js
+++ b/src/main/resources/static/js/marker-places.js
@@ -3,47 +3,54 @@ let selectedPlaces = [];
 
 // 여행지를 선택하여 배열에 추가하는 함수
 function addPlace(place) {
-    // 선택한 여행지를 배열에 추가
     selectedPlaces.push(place);
 }
 
 // "코스에 추가" 버튼 클릭 시 호출되는 함수
 function addToCourse(contentId) {
-    // API 호출하여 여행지의 정보 가져오기
-    fetch(`/api-test/detail?contentId=${contentId}`)
-        .then(response => {
-            if (!response.ok) {
-                // 응답이 성공적이지 않을 때 에러 처리
-                throw new Error('API 요청이 실패했습니다.');
-            }
-            // JSON 형태로 변환하여 반환
-            return response.json();
-        })
-        .then(data => {
-            // 여행지의 정보를 가져와서 선택한 여행지 배열에 추가
-            const place = {
-                contentId: contentId,
-                title: data.response.body.items.item[0].title
-            };
-            addPlace(place);
+    // 이미 선택한 여행지인지 확인
+    const isAlreadySelected = selectedPlaces.some(selectedPlace => selectedPlace.contentId === contentId);
 
-            // 선택한 여행지 목록을 화면에 표시
-            renderSelectedPlaces();
+    // 이미 선택한 여행지가 아니라면 정보를 가져와서 배열에 추가
+    if (!isAlreadySelected) {
+        // API 호출하여 여행지의 정보 가져오기
+        fetch(`/api-test/detail?contentId=${contentId}`)
+            .then(response => {
+                if (!response.ok) {
+                    // 응답이 성공적이지 않을 때 에러 처리
+                    throw new Error('API 요청이 실패했습니다.');
+                }
+                // JSON 형태로 변환하여 반환
+                return response.json();
+            })
+            .then(data => {
+                // 여행지의 정보를 가져와서 선택한 여행지 배열에 추가
+                const place = {
+                    contentId: contentId,
+                    title: data.response.body.items.item[0].title
+                };
+                addPlace(place);
 
-            // 여행지 좌표를 가져와 지도에 마커 표시
-            const coordinates = [{
-                mapx: parseFloat(data.response.body.items.item[0].mapx),
-                mapy: parseFloat(data.response.body.items.item[0].mapy)
-            }];
-            // 가져온 좌표값으로 마커를 표시합니다
-            displayMarkers(coordinates);
-        })
-        .catch(error => {
-            // API 요청이 실패했을 때 에러 처리
-            alert(error.message);
-            console.error('Error:', error);
-        });
+                // 선택한 여행지 목록을 화면에 표시
+                renderSelectedPlaces();
 
+                // 여행지 좌표를 가져와 지도에 마커 표시
+                const coordinates = [{
+                    mapx: parseFloat(data.response.body.items.item[0].mapx),
+                    mapy: parseFloat(data.response.body.items.item[0].mapy)
+                }];
+                // 가져온 좌표값으로 마커를 표시합니다
+                displayMarkers(coordinates);
+            })
+            .catch(error => {
+                // API 요청이 실패했을 때 에러 처리
+                alert(error.message);
+                console.error('Error:', error);
+            });
+    } else {
+        // 이미 선택한 여행지라면 경고 메시지 표시
+        alert('이미 선택한 여행지입니다.');
+    }
 }
 
 

--- a/src/main/resources/static/js/marker-places.js
+++ b/src/main/resources/static/js/marker-places.js
@@ -64,6 +64,16 @@ function renderSelectedPlaces() {
     selectedPlaces.forEach(place => {
         let listItem = document.createElement("li");
         listItem.textContent = place.title; // 여행지 이름 등 필요한 정보를 여기서 표시
+
+        // 삭제 버튼 추가
+        let removeButton = document.createElement("button");
+        removeButton.textContent = "X";
+        removeButton.classList.add("remove-button"); // CSS 클래스 추가
+
+        // 리스트 아이템에 삭제 버튼 추가
+        listItem.appendChild(removeButton);
+
+        // 리스트 아이템을 목록에 추가
         selectedPlacesList.appendChild(listItem);
     });
 }

--- a/src/main/resources/templates/sample-map.html
+++ b/src/main/resources/templates/sample-map.html
@@ -36,7 +36,16 @@
 
 <!-- 코스 생성 버튼과 선택한 여행지 리스트 -->
 <div class="extra-content">
-    <button id="course-create-btn" onclick="toggleSidebar()">코스 생성</button>
+    <button id="course-create-btn" onclick="toggleCourseForm()">코스 생성</button>
+
+    <!-- HTML 코드 -->
+    <div id="courseForm" style="display: none;">
+        <input type="text" id="courseTitle" placeholder="코스 제목">
+        <input type="text" id="courseDesc" placeholder="코스 설명">
+        <!-- 여기에 코스의 장소를 입력받는 UI를 추가할 수 있습니다. -->
+        <button onclick="createCourse()">코스 생성</button>
+    </div>
+
     <h3>선택한 여행지</h3>
     <ul id="selected-places-list">
         <!-- 선택한 여행지가 여기에 동적으로 추가됩니다 -->
@@ -59,5 +68,24 @@
 <script th:src="@{/js/search-places.js}"></script>
 <script th:src="@{/js/details-places.js}"></script>
 <script th:src="@{/js/marker-places.js}"></script>
+<script>
+    // JavaScript 코드
+    function toggleCourseForm() {
+        const courseForm = document.getElementById('courseForm');
+        if (courseForm.style.display === 'none') {
+            courseForm.style.display = 'block'; // 코스 생성 폼 보이기
+        } else {
+            courseForm.style.display = 'none'; // 코스 생성 폼 숨기기
+        }
+    }
+
+    function createCourse() {
+        const title = document.getElementById('courseTitle').value;
+        const desc = document.getElementById('courseDesc').value;
+        // 여기에 코스의 장소를 입력받는 코드를 추가할 수 있습니다.
+
+        // AJAX 또는 다른 방법을 사용하여 서버로 DTO를 전송할 수 있습니다.
+    }
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/sample-map.html
+++ b/src/main/resources/templates/sample-map.html
@@ -40,10 +40,12 @@
 
     <!-- HTML 코드 -->
     <div id="courseForm" style="display: none;">
-        <input type="text" id="courseTitle" placeholder="코스 제목">
-        <input type="text" id="courseDesc" placeholder="코스 설명">
-        <!-- 여기에 코스의 장소를 입력받는 UI를 추가할 수 있습니다. -->
-        <button onclick="createCourse()">코스 생성</button>
+        <form th:action="@{/api/v1/courses}" method="post">
+            <input type="text" id="courseTitle" name="title" placeholder="코스 제목">
+            <input type="text" id="courseDesc" name="desc" placeholder="코스 설명">
+            <!-- 여기에 코스의 장소를 입력받는 UI를 추가할 수 있습니다. -->
+            <button type="submit">코스 생성</button>
+        </form>
     </div>
 
     <h3>선택한 여행지</h3>
@@ -79,13 +81,6 @@
         }
     }
 
-    function createCourse() {
-        const title = document.getElementById('courseTitle').value;
-        const desc = document.getElementById('courseDesc').value;
-        // 여기에 코스의 장소를 입력받는 코드를 추가할 수 있습니다.
-
-        // AJAX 또는 다른 방법을 사용하여 서버로 DTO를 전송할 수 있습니다.
-    }
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/sample-map.html
+++ b/src/main/resources/templates/sample-map.html
@@ -15,7 +15,7 @@
 
 <!-- 사이드바 -->
 <div class="sidebar">
-    <h3>코스 생성</h3>
+    <h3>여행지 검색</h3>
     <!-- 여행지 검색창 -->
     <div class="search-container">
         <input type="text" id="search" name="search" placeholder="여행지를 검색하세요">
@@ -25,17 +25,22 @@
     <!-- 여행지 리스트 -->
     <div id="places-list">
         <h3 id="search-results-title">검색 결과</h3>
+
         <p id="page-info">총 <span id="total-results">0</span> 개의 결과 중 <span id="start-result">0</span> - <span id="end-result">0</span></p>
         <ul id="search-results">
             <!-- 검색 결과가 여기에 동적으로 추가됩니다 -->
         </ul>
         <div id="page-numbers"></div>
-
-        <h3>선택한 여행지</h3>
-        <ul id="selected-places">
-            <!-- 여행지가 선택되면 여기에 동적으로 추가됩니다 -->
-        </ul>
     </div>
+</div>
+
+<!-- 코스 생성 버튼과 선택한 여행지 리스트 -->
+<div class="extra-content">
+    <button id="course-create-btn" onclick="toggleSidebar()">코스 생성</button>
+    <h3>선택한 여행지</h3>
+    <ul id="selected-places-list">
+        <!-- 선택한 여행지가 여기에 동적으로 추가됩니다 -->
+    </ul>
 </div>
 
 <!-- 모달 창 -->
@@ -47,11 +52,6 @@
             <!-- 여기에 상세 정보를 동적으로 추가할 수 있습니다 -->
         </div>
     </div>
-</div>
-
-<!-- 메인 컨텐츠 -->
-<div class="content">
-    <!-- 추가적인 컨텐츠를 여기에 배치하세요 -->
 </div>
 
 <!-- 필요한 JavaScript 코드를 추가할 수 있습니다 -->


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/create-course

### 🔑 주요 변경사항
- 코스에 추가할 여행지 리스트를 화면에 표시 
   - 여행지들이 배열에 저장되도록 코드를 작성했습니다. 추후에 코스 정보를 저장할 때는 배열을 요청 데이터로 전송하면 될거같습니다. (ex. Fetch API)
   - 여행지가 배열에 저장될 때 중복된 데이터는 저장되지 못하도록 설정했습니다.
   - 선택한 여행지 삭제 버튼 기능은 미구현 입니다
 - 기타 CSS 적용 

### 🏞 스크린샷
`코스에 추가` 버튼을 누르면 선택한 여행지에 여행지가 추가됩니다.
<img width="1402" alt="image" src="https://github.com/like-lion-3team/trip/assets/110027583/3f69f7cf-ca7c-41b3-ae0c-dd6fb044b7d1">
이미 선택된 여행지 추가 불가
<img width="766" alt="image" src="https://github.com/like-lion-3team/trip/assets/110027583/5cc754ae-7eae-4ce1-b33b-b0f867aa241c">



