### PR TITLE
feat(places): 단일 여행지 정보 데이터베이스에 저장

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
+++ b/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
@@ -4,21 +4,25 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.traveloper.tourfinder.api.KTO.dto.KTOKeywordSearchDto;
 import com.traveloper.tourfinder.api.KTO.dto.detail.DetailsCommonDto;
 import com.traveloper.tourfinder.api.KTO.service.KTOApiService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
-@Slf4j
+@Tag(name = "Place", description = "여행지와 관련된 API")
 @RestController
+@RequestMapping("api/v1/places")
 @RequiredArgsConstructor
 public class PlaceController {
     private final KTOApiService ktoApiService;
 
     // 관광정보 서비스 API 여행지 정보 검색
-    @GetMapping("/api-test/search")
+    @GetMapping("/search")
     public KTOKeywordSearchDto searchPlaces(
             @RequestParam("keyword")
             String keyword,
@@ -30,11 +34,12 @@ public class PlaceController {
     }
 
     // 관광정보 서비스 API 여행지 정보 검색
-    @GetMapping("/api-test/detail")
+    @GetMapping("/detail")
     public DetailsCommonDto placesDetails(
             @RequestParam("contentId")
             String contentId
     ) {
         return ktoApiService.getPlaceDetails(contentId);
     }
+
 }

--- a/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
+++ b/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
@@ -3,7 +3,10 @@ package com.traveloper.tourfinder.course.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.traveloper.tourfinder.api.KTO.dto.KTOKeywordSearchDto;
 import com.traveloper.tourfinder.api.KTO.dto.detail.DetailsCommonDto;
+import com.traveloper.tourfinder.api.KTO.dto.detail.DetailsItemDto;
 import com.traveloper.tourfinder.api.KTO.service.KTOApiService;
+import com.traveloper.tourfinder.course.dto.PlaceDto;
+import com.traveloper.tourfinder.course.service.PlaceService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PlaceController {
     private final KTOApiService ktoApiService;
+    private final PlaceService placeService;
 
     // 관광정보 서비스 API 여행지 정보 검색
     @GetMapping("/search")
@@ -42,4 +46,14 @@ public class PlaceController {
         return ktoApiService.getPlaceDetails(contentId);
     }
 
+    // 여행지 저장 (코스에 추가를 누를떄마다)
+    @PostMapping("/save")
+    public PlaceDto savePlaces(
+            @RequestParam("contentId")
+            String contentId
+    ) {
+        DetailsItemDto itemDto = (DetailsItemDto) ktoApiService
+                .getPlaceDetails(contentId).getResponse().getBody().getItems().getItem();
+        return placeService.savePlaces(itemDto);
+    }
 }

--- a/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
+++ b/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
@@ -8,6 +8,7 @@ import com.traveloper.tourfinder.api.KTO.service.KTOApiService;
 import com.traveloper.tourfinder.course.dto.PlaceDto;
 import com.traveloper.tourfinder.course.service.PlaceService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,13 +48,19 @@ public class PlaceController {
     }
 
     // 여행지 저장 (코스에 추가를 누를떄마다)
-    @PostMapping("/save")
+    @GetMapping("/save")
     public PlaceDto savePlaces(
             @RequestParam("contentId")
             String contentId
     ) {
-        DetailsItemDto itemDto = (DetailsItemDto) ktoApiService
-                .getPlaceDetails(contentId).getResponse().getBody().getItems().getItem();
+        DetailsItemDto itemDto = ktoApiService
+                .getPlaceDetails(contentId)
+                .getResponse()
+                .getBody()
+                .getItems()
+                .getItem()
+                .get(0); // item 리스트에서 첫번째 원소를 가져와서 사용해야 함.
+
         return placeService.savePlaces(itemDto);
     }
 }

--- a/src/main/java/com/traveloper/tourfinder/course/service/PlaceService.java
+++ b/src/main/java/com/traveloper/tourfinder/course/service/PlaceService.java
@@ -1,5 +1,8 @@
 package com.traveloper.tourfinder.course.service;
 
+import com.traveloper.tourfinder.api.KTO.dto.detail.DetailsItemDto;
+import com.traveloper.tourfinder.course.dto.PlaceDto;
+import com.traveloper.tourfinder.course.entity.Place;
 import com.traveloper.tourfinder.course.repo.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,4 +13,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaceService {
     private final PlaceRepository placeRepository;
+
+    public PlaceDto savePlaces(DetailsItemDto detailsCommonDto) {
+        Place place = Place.builder()
+                .title(detailsCommonDto.getTitle())
+                .thumbnailUrl(detailsCommonDto.getFirstimage())
+                .lng(Double.valueOf(detailsCommonDto.getMapx()))
+                .lat(Double.valueOf(detailsCommonDto.getMapy()))
+                .build();
+        return PlaceDto.fromEntity(placeRepository.save(place));
+    }
 }

--- a/src/main/resources/static/js/details-places.js
+++ b/src/main/resources/static/js/details-places.js
@@ -1,7 +1,7 @@
 // 여행지 상세 정보 API 호출
 function getPlaceDetails(contentId) {
     // API 호출
-    fetch(`/api-test/detail?contentId=${contentId}`)
+    fetch(`/api/v1/places/detail?contentId=${contentId}`)
         .then(response => {
             if (!response.ok) {
                 // 응답이 성공적이지 않을 때 에러 처리

--- a/src/main/resources/static/js/marker-places.js
+++ b/src/main/resources/static/js/marker-places.js
@@ -14,7 +14,7 @@ function addToCourse(contentId) {
     // 이미 선택한 여행지가 아니라면 정보를 가져와서 배열에 추가
     if (!isAlreadySelected) {
         // API 호출하여 여행지의 정보 가져오기
-        fetch(`/api-test/detail?contentId=${contentId}`)
+        fetch(`/api/v1/places/detail?contentId=${contentId}`)
             .then(response => {
                 if (!response.ok) {
                     // 응답이 성공적이지 않을 때 에러 처리

--- a/src/main/resources/static/js/search-places.js
+++ b/src/main/resources/static/js/search-places.js
@@ -12,7 +12,7 @@ function searchPlaces() {
         alert("검색어를 입력하세요.");
     } else {
         // 검색어가 비어있지 않을 경우 API 요청 보내기
-        fetch(`/api-test/search?keyword=${searchQuery}&pageNo=${currentPage}`)
+        fetch(`/api/v1/places/search?keyword=${searchQuery}&pageNo=${currentPage}`)
             .then(response => {
                 if (!response.ok) {
                     // 응답이 성공적이지 않을 때 에러 처리


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/places

### 🔑 주요 변경사항
- KtoApi 의 여행지 상세 정보 조회 메서드(`getPlaceDetails`)를 통하여 특정 contentId 에 해당하는 개별 여행지 정보를 데이터베이스에 저장하도록 구현하였습니다.
- 당장은 코스 id 와 address 부분은 우선 제외 

### 🏞 스크린샷
반환된 placeDto 의 모습
<img width="765" alt="image" src="https://github.com/like-lion-3team/trip/assets/110027583/a7619f04-b73c-4e7f-9974-4456f56239d9">
DB 저장
<img width="452" alt="image" src="https://github.com/like-lion-3team/trip/assets/110027583/1bd1e308-e67d-43cc-9858-94e1c3f425ce">


### 관련 이슈
- `KtoapiService`의 `getTripPlaces` 메서드를 호출하면 무수히 많은 키워드 검색 결과 리스트들이 나오게 되는데, 
- 이때 특정 `contetnId` 에 해당하는 단일 여행지 정보를 가져오는 방법을 찾아봐야할 것 같습니다..
