### PR TITLE
feat(create-course): 여행지 삭제 버튼 클릭 기능, PlaceDto 에 address 정보 포함

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/api/KTO/dto/detail/DetailsItemDto.java
+++ b/src/main/java/com/traveloper/tourfinder/api/KTO/dto/detail/DetailsItemDto.java
@@ -16,6 +16,9 @@ public class DetailsItemDto {
     private String firstimage;
     private String firstimage2;
     private String cpyrhtDivCd;
+    private String addr1;
+    private String addr2;
+    private String zipcode;
     private String mapx;
     private String mapy;
     private String mlevel;

--- a/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOApiService.java
+++ b/src/main/java/com/traveloper/tourfinder/api/KTO/service/KTOApiService.java
@@ -54,6 +54,7 @@ public class KTOApiService {
         params.put("firstImageYN", "Y");
         params.put("mapinfoYN", "Y");
         params.put("overviewYN", "Y");
+        params.put("addrinfoYN", "Y");
         return ktoSearchService.DetailCommon(params);
     }
 }

--- a/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
+++ b/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
@@ -4,21 +4,25 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.traveloper.tourfinder.api.KTO.dto.KTOKeywordSearchDto;
 import com.traveloper.tourfinder.api.KTO.dto.detail.DetailsCommonDto;
 import com.traveloper.tourfinder.api.KTO.service.KTOApiService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
-@Slf4j
+@Tag(name = "Place", description = "여행지와 관련된 API")
 @RestController
+@RequestMapping("api/v1/places")
 @RequiredArgsConstructor
 public class PlaceController {
     private final KTOApiService ktoApiService;
 
     // 관광정보 서비스 API 여행지 정보 검색
-    @GetMapping("/api-test/search")
+    @GetMapping("/search")
     public KTOKeywordSearchDto searchPlaces(
             @RequestParam("keyword")
             String keyword,
@@ -30,11 +34,12 @@ public class PlaceController {
     }
 
     // 관광정보 서비스 API 여행지 정보 검색
-    @GetMapping("/api-test/detail")
+    @GetMapping("/detail")
     public DetailsCommonDto placesDetails(
             @RequestParam("contentId")
             String contentId
     ) {
         return ktoApiService.getPlaceDetails(contentId);
     }
+
 }

--- a/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
+++ b/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
@@ -3,7 +3,10 @@ package com.traveloper.tourfinder.course.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.traveloper.tourfinder.api.KTO.dto.KTOKeywordSearchDto;
 import com.traveloper.tourfinder.api.KTO.dto.detail.DetailsCommonDto;
+import com.traveloper.tourfinder.api.KTO.dto.detail.DetailsItemDto;
 import com.traveloper.tourfinder.api.KTO.service.KTOApiService;
+import com.traveloper.tourfinder.course.dto.PlaceDto;
+import com.traveloper.tourfinder.course.service.PlaceService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PlaceController {
     private final KTOApiService ktoApiService;
+    private final PlaceService placeService;
 
     // 관광정보 서비스 API 여행지 정보 검색
     @GetMapping("/search")
@@ -42,4 +46,14 @@ public class PlaceController {
         return ktoApiService.getPlaceDetails(contentId);
     }
 
+    // 여행지 저장 (코스에 추가를 누를떄마다)
+    @PostMapping("/save")
+    public PlaceDto savePlaces(
+            @RequestParam("contentId")
+            String contentId
+    ) {
+        DetailsItemDto itemDto = (DetailsItemDto) ktoApiService
+                .getPlaceDetails(contentId).getResponse().getBody().getItems().getItem();
+        return placeService.savePlaces(itemDto);
+    }
 }

--- a/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
+++ b/src/main/java/com/traveloper/tourfinder/course/controller/PlaceController.java
@@ -8,6 +8,7 @@ import com.traveloper.tourfinder.api.KTO.service.KTOApiService;
 import com.traveloper.tourfinder.course.dto.PlaceDto;
 import com.traveloper.tourfinder.course.service.PlaceService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,13 +48,19 @@ public class PlaceController {
     }
 
     // 여행지 저장 (코스에 추가를 누를떄마다)
-    @PostMapping("/save")
+    @GetMapping("/save")
     public PlaceDto savePlaces(
             @RequestParam("contentId")
             String contentId
     ) {
-        DetailsItemDto itemDto = (DetailsItemDto) ktoApiService
-                .getPlaceDetails(contentId).getResponse().getBody().getItems().getItem();
+        DetailsItemDto itemDto = ktoApiService
+                .getPlaceDetails(contentId)
+                .getResponse()
+                .getBody()
+                .getItems()
+                .getItem()
+                .get(0); // item 리스트에서 첫번째 원소를 가져와서 사용해야 함.
+
         return placeService.savePlaces(itemDto);
     }
 }

--- a/src/main/java/com/traveloper/tourfinder/course/service/PlaceService.java
+++ b/src/main/java/com/traveloper/tourfinder/course/service/PlaceService.java
@@ -1,5 +1,8 @@
 package com.traveloper.tourfinder.course.service;
 
+import com.traveloper.tourfinder.api.KTO.dto.detail.DetailsItemDto;
+import com.traveloper.tourfinder.course.dto.PlaceDto;
+import com.traveloper.tourfinder.course.entity.Place;
 import com.traveloper.tourfinder.course.repo.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,4 +13,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaceService {
     private final PlaceRepository placeRepository;
+
+    public PlaceDto savePlaces(DetailsItemDto detailsCommonDto) {
+        Place place = Place.builder()
+                .title(detailsCommonDto.getTitle())
+                .thumbnailUrl(detailsCommonDto.getFirstimage())
+                .lng(Double.valueOf(detailsCommonDto.getMapx()))
+                .lat(Double.valueOf(detailsCommonDto.getMapy()))
+                .build();
+        return PlaceDto.fromEntity(placeRepository.save(place));
+    }
 }

--- a/src/main/java/com/traveloper/tourfinder/course/service/PlaceService.java
+++ b/src/main/java/com/traveloper/tourfinder/course/service/PlaceService.java
@@ -18,6 +18,7 @@ public class PlaceService {
         Place place = Place.builder()
                 .title(detailsCommonDto.getTitle())
                 .thumbnailUrl(detailsCommonDto.getFirstimage())
+                .address(detailsCommonDto.getAddr1() + " " + detailsCommonDto.getAddr2())
                 .lng(Double.valueOf(detailsCommonDto.getMapx()))
                 .lat(Double.valueOf(detailsCommonDto.getMapy()))
                 .build();

--- a/src/main/resources/static/js/details-places.js
+++ b/src/main/resources/static/js/details-places.js
@@ -1,7 +1,7 @@
 // 여행지 상세 정보 API 호출
 function getPlaceDetails(contentId) {
     // API 호출
-    fetch(`/api-test/detail?contentId=${contentId}`)
+    fetch(`/api/v1/places/detail?contentId=${contentId}`)
         .then(response => {
             if (!response.ok) {
                 // 응답이 성공적이지 않을 때 에러 처리

--- a/src/main/resources/static/js/marker-places.js
+++ b/src/main/resources/static/js/marker-places.js
@@ -14,7 +14,7 @@ function addToCourse(contentId) {
     // 이미 선택한 여행지가 아니라면 정보를 가져와서 배열에 추가
     if (!isAlreadySelected) {
         // API 호출하여 여행지의 정보 가져오기
-        fetch(`/api-test/detail?contentId=${contentId}`)
+        fetch(`/api/v1/places/detail?contentId=${contentId}`)
             .then(response => {
                 if (!response.ok) {
                     // 응답이 성공적이지 않을 때 에러 처리

--- a/src/main/resources/static/js/marker-places.js
+++ b/src/main/resources/static/js/marker-places.js
@@ -1,6 +1,9 @@
 // 여행지를 저장할 배열 초기화
 let selectedPlaces = [];
 
+// 마커 객체를 저장할 배열 초기화
+let markers = [];
+
 // 여행지를 선택하여 배열에 추가하는 함수
 function addPlace(place) {
     selectedPlaces.push(place);
@@ -27,20 +30,17 @@ function addToCourse(contentId) {
                 // 여행지의 정보를 가져와서 선택한 여행지 배열에 추가
                 const place = {
                     contentId: contentId,
-                    title: data.response.body.items.item[0].title
+                    title: data.response.body.items.item[0].title,
+                    mapx: parseFloat(data.response.body.items.item[0].mapx),
+                    mapy: parseFloat(data.response.body.items.item[0].mapy)
                 };
                 addPlace(place);
 
                 // 선택한 여행지 목록을 화면에 표시
                 renderSelectedPlaces();
 
-                // 여행지 좌표를 가져와 지도에 마커 표시
-                const coordinates = [{
-                    mapx: parseFloat(data.response.body.items.item[0].mapx),
-                    mapy: parseFloat(data.response.body.items.item[0].mapy)
-                }];
                 // 가져온 좌표값으로 마커를 표시합니다
-                displayMarkers(coordinates);
+                displayMarkers();
             })
             .catch(error => {
                 // API 요청이 실패했을 때 에러 처리
@@ -53,16 +53,43 @@ function addToCourse(contentId) {
     }
 }
 
-
-
 // "X" 버튼을 클릭하여 선택한 여행지를 삭제하는 함수
 function removePlace(contentId) {
     // 선택한 여행지 배열에서 해당 contentId를 가진 여행지 제거
     selectedPlaces = selectedPlaces.filter(place => place.contentId !== contentId);
     // 변경된 선택한 여행지 목록을 다시 화면에 표시
     renderSelectedPlaces();
+
+    // 해당 contentId를 가진 마커를 찾아서 제거
+    markers = markers.filter(marker => {
+        if (marker.contentId === contentId) {
+            marker.setMap(null); // 해당 마커를 지도에서 제거
+            return false; // 마커 배열에서 제거
+        }
+        return true; // 유지되어야 하는 마커는 다시 배열에 추가
+    });
+
+    // 마커 업데이트
+    displayMarkers();
 }
 
+// 여행지의 좌표를 지도에 마커로 표시하는 함수
+function displayMarkers(coordinates) {
+    markers.forEach(marker => {
+        marker.setMap(null);
+    })
+    markers = [];
+    // 선택한 여행지 배열을 순회하면서 각각의 좌표에 마커를 표시
+    selectedPlaces.forEach(place => {
+        var position = new naver.maps.LatLng(place.mapy, place.mapx);
+        var marker = new naver.maps.Marker({
+            position: position,
+            map: map
+        });
+        // 생성된 마커를 markers 배열에 추가
+        markers.push(marker);
+    });
+}
 
 // 선택한 여행지를 화면에 표시하는 함수
 function renderSelectedPlaces() {
@@ -94,15 +121,5 @@ function renderSelectedPlaces() {
     });
 }
 
-// 여행지의 좌표를 지도에 마커로 표시하는 함수
-function displayMarkers(coordinates) {
-    // 새로운 마커들을 추가합니다
-    coordinates.forEach(coord => {
-        var position = new naver.maps.LatLng(coord.mapy, coord.mapx);
-        var marker = new naver.maps.Marker({
-            position: position,
-            map: map
-        });
-    });
-}
+
 

--- a/src/main/resources/static/js/marker-places.js
+++ b/src/main/resources/static/js/marker-places.js
@@ -54,6 +54,16 @@ function addToCourse(contentId) {
 }
 
 
+
+// "X" 버튼을 클릭하여 선택한 여행지를 삭제하는 함수
+function removePlace(contentId) {
+    // 선택한 여행지 배열에서 해당 contentId를 가진 여행지 제거
+    selectedPlaces = selectedPlaces.filter(place => place.contentId !== contentId);
+    // 변경된 선택한 여행지 목록을 다시 화면에 표시
+    renderSelectedPlaces();
+}
+
+
 // 선택한 여행지를 화면에 표시하는 함수
 function renderSelectedPlaces() {
     let selectedPlacesList = document.getElementById("selected-places-list");
@@ -69,6 +79,12 @@ function renderSelectedPlaces() {
         let removeButton = document.createElement("button");
         removeButton.textContent = "X";
         removeButton.classList.add("remove-button"); // CSS 클래스 추가
+
+        // 삭제 버튼에 이벤트 리스너 추가
+        removeButton.addEventListener("click", () => {
+            // 해당 여행지를 선택한 여행지 배열에서 삭제
+            removePlace(place.contentId);
+        });
 
         // 리스트 아이템에 삭제 버튼 추가
         listItem.appendChild(removeButton);
@@ -89,3 +105,4 @@ function displayMarkers(coordinates) {
         });
     });
 }
+

--- a/src/main/resources/static/js/search-places.js
+++ b/src/main/resources/static/js/search-places.js
@@ -12,7 +12,7 @@ function searchPlaces() {
         alert("검색어를 입력하세요.");
     } else {
         // 검색어가 비어있지 않을 경우 API 요청 보내기
-        fetch(`/api-test/search?keyword=${searchQuery}&pageNo=${currentPage}`)
+        fetch(`/api/v1/places/search?keyword=${searchQuery}&pageNo=${currentPage}`)
             .then(response => {
                 if (!response.ok) {
                     // 응답이 성공적이지 않을 때 에러 처리


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat(create-course)

### 🔑 주요 변경사항
- 선택한 여행지를 삭제하는 버튼을 클릭시 리스트에서 제거, 마커 제거
- `KtoApiSerivce` 의 `getPlaceDetails` 메서드에 `addrinfoYN`를 추가하여 API 응답 데이터에 주소 정보가 포함되도록 설정
- `address` 값이 `PlaceDto` 에 포함되고, DB 에도 정상적으로 저장

<img width="588" alt="image" src="https://github.com/like-lion-3team/trip/assets/110027583/8f32d606-72d5-40fc-84a7-011e3ffec6e2">

<img width="620" alt="image" src="https://github.com/like-lion-3team/trip/assets/110027583/a4195174-d9a0-445c-9aec-e91be1328960">



