### PR TITLE
fix(oauth): 소셜 회원가입 닉네임 중복문제, 로그인시 로딩 표시

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
@@ -66,8 +66,12 @@ public class MemberService implements UserDetailsService {
             CreateMemberDto dto
     ) {
         // 닉네임 중복체크, 이메일 중복체크
-        if (memberRepository.existsByEmail(dto.getEmail()) || memberRepository.existsByNickname(dto.getNickname()))
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        if (memberRepository.existsByEmail(dto.getEmail())){
+            throw new GlobalExceptionHandler(CustomGlobalErrorCode.EMAIL_ALREADY_EXIST);
+        } else if (memberRepository.existsByNickname(dto.getNickname()) ){
+            throw new GlobalExceptionHandler(CustomGlobalErrorCode.NICKNAME_ALREADY_EXIST);
+        }
+
 
         String uuid = UUID.randomUUID().toString();
 

--- a/src/main/java/com/traveloper/tourfinder/oauth2/service/GoogleOauthService.java
+++ b/src/main/java/com/traveloper/tourfinder/oauth2/service/GoogleOauthService.java
@@ -62,20 +62,16 @@ public class GoogleOauthService {
     public String googleLogin(
             String code
     ) {
-        System.out.printf(code + "코드");
         String googleAccessToken = getAccessToken(code).getAccessToken();
-        System.out.printf(googleAccessToken + "구글 액세스 토큰");
         GoogleUserProfile userInfo = getProfile(googleAccessToken);
         String email = userInfo.getEmail();
-        String nickname = userInfo.getName();
+        String nickname = userInfo.getEmail() + "_google";
 
         Optional<Member> memberOpt = memberRepository.findMemberByEmail(email);
         if (memberOpt.isEmpty()) {
-            // 사용자가 존재하지 않으면 회원가입 및 연동 후 토큰 전달
             MemberDto memberDto = socialOauthService.handleNewUser(SOCIAL_PROVIDER_NAME,nickname, email);
             return socialOauthService.getRedirectPathAndSaveOauth2AuthorizeToken(SOCIAL_PROVIDER_NAME, memberDto);
         } else {
-            // 존재하는 사용자라면 연동 처리
             MemberDto memberDto = socialOauthService.handleExistingUser(SOCIAL_PROVIDER_NAME,memberOpt.get());
             return socialOauthService.getRedirectPathAndSaveOauth2AuthorizeToken(SOCIAL_PROVIDER_NAME, memberDto);
         }
@@ -86,8 +82,6 @@ public class GoogleOauthService {
         RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
-
-        System.out.printf("엑세스토큰 생성시 사용할 코드" + code);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.setCacheControl(CacheControl.noCache());
@@ -120,7 +114,6 @@ public class GoogleOauthService {
 
 
         HttpEntity<String> request = new HttpEntity<>(headers);
-        System.out.println(request.getHeaders().get("Authorization") + "    인증토큰");
 
         try {
             ResponseEntity<String> response = restTemplate.exchange(

--- a/src/main/java/com/traveloper/tourfinder/oauth2/service/KakaoOauthService.java
+++ b/src/main/java/com/traveloper/tourfinder/oauth2/service/KakaoOauthService.java
@@ -84,13 +84,15 @@ public class KakaoOauthService {
         String kakaoAccessToken = getAccessTokenUsingCode(code).getAccess_token();
         KakaoUserProfile userInfo = getUserInfoUsingAccessToken(kakaoAccessToken);
         String email = userInfo.getKakaoAccount().getEmail();
-        String nickname = userInfo.getProperties().getNickname();
+        String nickname = userInfo.getKakaoAccount().getEmail() + "_kakao";
 
         Optional<Member> memberOpt = memberRepository.findMemberByEmail(email);
         if (memberOpt.isEmpty()) {
+            System.out.println("유저가 존재하지 않음");
 
             // 사용자가 존재하지 않으면 회원가입 및 연동 후 토큰 전달
             MemberDto memberDto = socialOauthService.handleNewUser(SOCIAL_PROVIDER_NAME,nickname, email);
+            System.out.println(memberDto.getMemberName() + "멤버 아이디");
             return socialOauthService.getRedirectPathAndSaveOauth2AuthorizeToken(SOCIAL_PROVIDER_NAME, memberDto);
         } else {
             // 존재하는 사용자라면 연동 처리

--- a/src/main/java/com/traveloper/tourfinder/oauth2/service/NaverOauthService.java
+++ b/src/main/java/com/traveloper/tourfinder/oauth2/service/NaverOauthService.java
@@ -62,7 +62,7 @@ public class NaverOauthService {
         String naverAccessToken = getAccessToken(code).getAccess_token();
         NaverUserProfile userInfo = getProfile(naverAccessToken);
         String email = userInfo.getResponse().getEmail();
-        String nickname = userInfo.getResponse().getName();
+        String nickname = userInfo.getResponse().getEmail() + "_naver";
 
         Optional<Member> memberOpt = memberRepository.findMemberByEmail(email);
         if (memberOpt.isEmpty()) {
@@ -70,6 +70,8 @@ public class NaverOauthService {
             MemberDto memberDto = socialOauthService.handleNewUser(SOCIAL_PROVIDER_NAME,nickname, email);
             return socialOauthService.getRedirectPathAndSaveOauth2AuthorizeToken(SOCIAL_PROVIDER_NAME, memberDto);
         } else {
+            System.out.printf(memberOpt.get().getUuid() + "네이버 UUID");
+
             // 존재하는 사용자라면 연동 처리
             MemberDto memberDto = socialOauthService.handleExistingUser(SOCIAL_PROVIDER_NAME,memberOpt.get());
             return socialOauthService.getRedirectPathAndSaveOauth2AuthorizeToken(SOCIAL_PROVIDER_NAME, memberDto);

--- a/src/main/java/com/traveloper/tourfinder/oauth2/service/SocialOauthService.java
+++ b/src/main/java/com/traveloper/tourfinder/oauth2/service/SocialOauthService.java
@@ -71,7 +71,7 @@ public class SocialOauthService {
                 .email(email)
                 .password(password)
                 .build();
-
+        
         MemberDto memberDto = memberService.signup(createMemberDto);
         Member findMember = memberRepository.findMemberByUuid(memberDto.getUuid()).orElseThrow(
                 () -> {
@@ -91,11 +91,11 @@ public class SocialOauthService {
     public MemberDto handleExistingUser(String socialProviderName, Member member) {
         boolean isLinkedSocial = member.getSocialProviderMembers().stream()
                 .anyMatch(spm -> socialProviderName.equals(spm.getSocialProvider().getSocialProviderName()));
-        log.info("소셜 회원인지 체크:"+ isLinkedSocial);
         // 타겟 플랫폼 연동 체크
         if (!isLinkedSocial) {
             linkAccountWithSocialLogin(socialProviderName, member);
         }
+
 
         return MemberDto.builder()
                 .uuid(member.getUuid())
@@ -132,9 +132,6 @@ public class SocialOauthService {
      * */
     public String getRedirectPathAndSaveOauth2AuthorizeToken(String socialProviderName, MemberDto memberDto){
         UUID randomUUID = UUID.randomUUID();
-
-        System.out.printf(memberDto.getUuid() + "UUID");
-        System.out.printf(randomUUID + "UUID");
         redisRepo.saveOauth2AuthorizeToken(randomUUID,generateTokenDto(memberDto.getUuid())  );
         return "/oauth2/callback?socialProvider=" + socialProviderName + "&" + "token=" + randomUUID;
     }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -24,19 +24,14 @@
 
 
     <!-- Modal -->
-    <div class="modal fade" id="loginLoadingModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
+    <div class="modal fade" id="loginLoadingModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    ...
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                    <button type="button" class="btn btn-primary">Save changes</button>
+                <div class="modal-body text-center">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="sr-only"></span>
+                    </div>
+                    <p class="mt-3">로그인 처리 중...</p> <!-- 여기로 옮겼습니다 -->
                 </div>
             </div>
         </div>
@@ -58,6 +53,11 @@
 
                 <button class="btn btn-primary" onclick="login()">로그인</button>
                 <button class="btn btn-primary" onclick="goSignUpPage()">회원가입</button>
+                <div>
+                    <a>아이디 찾기</a>
+
+                    <a>비밀번호 찾기</a>
+                </div>
                 <hr>
                 <b>간편 로그인</b>
                 <div class="flex-column">
@@ -79,17 +79,21 @@
 
 </body>
 <script>
-    function openModal(){
-        var myModal = document.getElementById('loginLoadingModal')
-        // var myInput = document.getElementById('myInput')
 
-        myModal.addEventListener('shown.bs.modal', function () {
-            // myInput.focus()
-        })
+    function openModal() {
+        var myModal = new bootstrap.Modal(document.getElementById('loginLoadingModal'));
+
+        myModal.show();
     }
+
     function closeModal(){
+        var myModal = new bootstrap.Modal(document.getElementById('loginLoadingModal'));
 
+        myModal.close();
     }
+
+
+
 
     function goSignUpPage(){
         return window.location.href = "/sign-up"
@@ -100,12 +104,15 @@
         return window.location.href = "/api/v1/oauth2/kakao"
     }
     function naverLogin(){
+        openModal()
         return window.location.href = "/api/v1/oauth2/naver"
     }
     function googleLogin(){
+        openModal()
         return window.location.href = "/api/v1/oauth2/google"
     }
     async function login() {
+        openModal();
         //fetch
         const email = document.getElementById('email').value;
         const password = document.getElementById('password').value;
@@ -124,15 +131,19 @@
             const data = await response.json();
             if (response.status === 200) {
                 alert('로그인 성공');
+
                 localStorage.setItem('token', data.accessToken);
+                closeModal();
                 window.location.href = "/home";
 
             } else {
                 alert('로그인 실패2');
+                closeModal();
             }
         } catch (error) {
             console.error('에러처리:', error);
             alert('로그인 실패');
+            closeModal();
 
         }
 

--- a/src/main/resources/templates/oauth2-redirect.html
+++ b/src/main/resources/templates/oauth2-redirect.html
@@ -50,7 +50,7 @@
 
              const data = await response.json()
              localStorage.setItem("token",data.accessToken);
-             location.href = "/my-page"
+             location.href = "/home"
          } catch (e) {
              console.log(e)
              location.href = "/login"


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 💡 작업동기
- 로그인시 적절한 피드백이 없어서 화면이 멈춘 것 같은 느낌이 듬
- 소셜 로그인시 닉네임 중복으로 가입이 안되는 문제가 있었음

### 🔑 주요 변경사항
- 소셜 로그인시 각 소셜 사업자의 이름을 접미사로 붙혀서 닉네임을 생성 ex) `email@email.email + _kakao`
- 로그인시 로딩 표시


