### PR TITLE
fix(auth):회원가입시 이메일 인증 없이 회원 가입이 가능한 문제 수정

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/auth/controller/MemberController.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/controller/MemberController.java
@@ -42,7 +42,7 @@ public class MemberController {
             @RequestBody
             CreateMemberDto dto
     ) {
-        return ResponseEntity.ok(memberService.signup(dto));
+        return ResponseEntity.ok(memberService.signup(dto,"COMMON"));
     }
 
     @GetMapping("/send/{email}/code")

--- a/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
@@ -65,13 +65,18 @@ public class MemberService implements UserDetailsService {
     @Transactional
     public MemberDto signup(
             // 닉네임, 이메일, 비밀번호 입력받기
-            CreateMemberDto dto
+            CreateMemberDto dto,
+
+            // COMMON, SOCIAL
+            String type
     ) {
         // 닉네임 중복체크, 이메일 중복체크
         if (memberRepository.existsByEmail(dto.getEmail())){
             throw new GlobalExceptionHandler(CustomGlobalErrorCode.EMAIL_ALREADY_EXIST);
         } else if (memberRepository.existsByNickname(dto.getNickname()) ){
             throw new GlobalExceptionHandler(CustomGlobalErrorCode.NICKNAME_ALREADY_EXIST);
+        } else if (type.equals("COMMON") && redisRepo.getVerifyCode(dto.getEmail()).isEmpty() ){
+            throw new GlobalExceptionHandler(CustomGlobalErrorCode.PASSWORD_RECOVERY_CODE_MISS_MATCH);
         }
 
 

--- a/src/main/java/com/traveloper/tourfinder/oauth2/service/SocialOauthService.java
+++ b/src/main/java/com/traveloper/tourfinder/oauth2/service/SocialOauthService.java
@@ -84,7 +84,7 @@ public class SocialOauthService {
                 .password(password)
                 .build();
         
-        MemberDto memberDto = memberService.signup(createMemberDto);
+        MemberDto memberDto = memberService.signup(createMemberDto, "SOCIAL");
         Member findMember = memberRepository.findMemberByUuid(memberDto.getUuid()).orElseThrow(
                 () -> {
                     log.warn("회원 가입이 정상 처리되지 않았습니다.");

--- a/src/main/resources/templates/signUp.html
+++ b/src/main/resources/templates/signUp.html
@@ -265,11 +265,10 @@
                 location.href = '/login';
 
             } else {
-                alert('회원 가입 실패');
+                alert(data.message);
             }
         } catch (error) {
-            console.error('에러처리:', error);
-            alert('로그인 실패');
+
 
         }
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 💡 작업동기
- 회원 가입시 인증코드 및 이메일 인증 하지 않고 가입이 되는 문제 수정

### 🔑 주요 변경사항
- 회원 가입시 소셜 회원 가입인지 일반 회원 가입인지 `COMMON`, `SOCIAL` 키워드로 구분
- 회원 가입 메서드에 redis 저장소 조회해서 인증정보 체크하는 로직 추가
 
