### PR TITLE
fix(auth): facade.getCurrentMember() 예외처리

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/common/exception/CustomGlobalErrorCode.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/CustomGlobalErrorCode.java
@@ -42,7 +42,12 @@ public enum CustomGlobalErrorCode {
 
     // email
     PASSWORD_RECOVERY_CODE_MISS_MATCH(400,"7001","인증코드가 올바르지 않습니다"),
-    NOT_FOUND_PASSWORD_RECOVERY_CODE(400,"7002","인증 코드가 만료 되었습니다.");
+    NOT_FOUND_PASSWORD_RECOVERY_CODE(400,"7002","인증 코드가 만료 되었습니다."),
+
+    // token_auth
+    AUTHENTICATION_FAILED(403, "8001", "인증 확인에 실패했습니다.");
+
+
 
     private int status;
     private String code;

--- a/src/main/java/com/traveloper/tourfinder/common/util/AuthenticationFacade.java
+++ b/src/main/java/com/traveloper/tourfinder/common/util/AuthenticationFacade.java
@@ -2,6 +2,8 @@ package com.traveloper.tourfinder.common.util;
 
 import com.traveloper.tourfinder.auth.entity.CustomUserDetails;
 import com.traveloper.tourfinder.auth.entity.Member;
+import com.traveloper.tourfinder.common.exception.CustomGlobalErrorCode;
+import com.traveloper.tourfinder.common.exception.GlobalExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,8 +13,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AuthenticationFacade {
     public Member getCurrentMember() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails)  authentication.getPrincipal();
-        return userDetails.getMember();
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth.getPrincipal() instanceof CustomUserDetails userDetails) {
+            return userDetails.getMember();
+        } else {
+            throw new GlobalExceptionHandler(CustomGlobalErrorCode.AUTHENTICATION_FAILED);
+        }
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 💡 작업동기
- facade를 이용하는 메서드에서 사용자 인증정보가 없을 시 오류 코드가 계속나오는 문제 발생

### 🔑 주요 변경사항
- AuthenticationFacade에 간단한 예외처리 로직 추가

### 관련 이슈
- 변경 사항으로 인해 api 작동에 문제 없는지 체크 부탁드립니다.
