### PR TITLE
fix(auth):마이페이지, 토큰 관련 로직 수정

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/auth/controller/TokenController.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/controller/TokenController.java
@@ -4,6 +4,8 @@ import com.traveloper.tourfinder.auth.dto.Token.ReissuanceDto;
 import com.traveloper.tourfinder.auth.dto.Token.TokenDto;
 import com.traveloper.tourfinder.auth.service.TokenService;
 import com.traveloper.tourfinder.common.AppConstants;
+import com.traveloper.tourfinder.common.exception.CustomGlobalErrorCode;
+import com.traveloper.tourfinder.common.exception.GlobalExceptionHandler;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,9 +25,14 @@ public class TokenController {
             @RequestBody
             ReissuanceDto dto
     ) {
+        System.out.println("인자 테스트2");
+        if( dto.getAccessToken().isEmpty() || dto.getUuid().isEmpty()){
+            System.out.println("인자 테스트");
+            throw new GlobalExceptionHandler(CustomGlobalErrorCode.SERVICE_UNAVAILABLE);
+        }
         // TODO: AccessToken 재발급
         String token = tokenService.rolling(dto).orElseThrow(
-                () -> new RuntimeException("토큰 재발급 오류")
+                () -> new GlobalExceptionHandler(CustomGlobalErrorCode.TOKEN_EXPIRED)
         );
 
 

--- a/src/main/java/com/traveloper/tourfinder/auth/dto/Token/ReissuanceDto.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/dto/Token/ReissuanceDto.java
@@ -1,10 +1,12 @@
 package com.traveloper.tourfinder.auth.dto.Token;
 
-import lombok.Builder;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReissuanceDto {
     private String accessToken;
     private String uuid;

--- a/src/main/java/com/traveloper/tourfinder/auth/dto/Token/TokenDto.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/dto/Token/TokenDto.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 public class TokenDto {
     // 엑세스 토큰
     private String accessToken;
+    private String uuid;
 
     // 만료일
     private LocalDateTime expiredDate;

--- a/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
@@ -221,7 +221,7 @@ public class MemberService implements UserDetailsService {
 
     public MemberDto findMember(String uuid){
         Member member = memberRepository.findMemberByUuid(uuid).orElseThrow(
-                () -> new AccessDeniedException("유저를 찾을 수 없습니다.")
+                () -> new GlobalExceptionHandler(CustomGlobalErrorCode.NOT_FOUND_MEMBER)
         );
 
         return MemberDto.builder()

--- a/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/service/MemberService.java
@@ -129,6 +129,7 @@ public class MemberService implements UserDetailsService {
         }
 
         return TokenDto.builder()
+                .uuid(member.getUuid())
                 .accessToken(accessToken)
                 .expiredDate(LocalDateTime.now().plusSeconds(AppConstants.ACCESS_TOKEN_EXPIRE_SECOND))
                 .expiredSecond(AppConstants.ACCESS_TOKEN_EXPIRE_SECOND)

--- a/src/main/java/com/traveloper/tourfinder/common/AppConstants.java
+++ b/src/main/java/com/traveloper/tourfinder/common/AppConstants.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 public final class AppConstants {
 
-    public static final  Integer ACCESS_TOKEN_EXPIRE_SECOND = 60 * 3;
+    public static final  Integer ACCESS_TOKEN_EXPIRE_SECOND = 20;
     public static final  Integer REFRESH_TOKEN_EXPIRE_SECOND = 60 * 60 * 60;
     public static final  Integer EMAIL_VERIFY_CODE_EXPIRE_SECOND = 60 * 5;  // 5분
     public static final  Integer OAUTH2_AUTHORIZE_TOKEN_EXPIRE_SECOND = 60;

--- a/src/main/java/com/traveloper/tourfinder/common/config/PermitAllPath.java
+++ b/src/main/java/com/traveloper/tourfinder/common/config/PermitAllPath.java
@@ -19,6 +19,7 @@ public class PermitAllPath {
             "/api/v1/auth/send/*/code",
             "/api/v1/auth/email/*/verify-code/*",
             "/api/v1/auth/current-member",
+            "/api/v1/auth/token",
             "/api/v1/admin/auth/**",
             "/api/v1/admin/**",
 

--- a/src/main/java/com/traveloper/tourfinder/common/exception/CustomJwtExceptionFilter.java
+++ b/src/main/java/com/traveloper/tourfinder/common/exception/CustomJwtExceptionFilter.java
@@ -72,8 +72,8 @@ public class CustomJwtExceptionFilter extends OncePerRequestFilter {
                 }
 
                 if (!jwtTokenUtils.validate(token)) {
-                    log.info("올바르지 않은 토큰");
-                    setErrorResponse(CustomGlobalErrorCode.MALFORMED_TOKEN, response);
+                    log.info("토큰이 만료되었습니다.");
+                    setErrorResponse(CustomGlobalErrorCode.TOKEN_EXPIRED, response);
                     return;
                 }
 

--- a/src/main/java/com/traveloper/tourfinder/oauth2/service/SocialOauthService.java
+++ b/src/main/java/com/traveloper/tourfinder/oauth2/service/SocialOauthService.java
@@ -132,6 +132,7 @@ public class SocialOauthService {
 
         return TokenDto.builder()
                 .accessToken(accessToken)
+                .uuid(uuid)
                 .expiredDate(LocalDateTime.now().plusSeconds(AppConstants.ACCESS_TOKEN_EXPIRE_SECOND))
                 .expiredSecond(AppConstants.ACCESS_TOKEN_EXPIRE_SECOND)
                 .build();

--- a/src/main/resources/static/js/retryToken.js
+++ b/src/main/resources/static/js/retryToken.js
@@ -1,0 +1,38 @@
+async function refreshTokenAndRetryRequest(url) {
+    const token = localStorage.getItem("token")
+    const uuid = localStorage.getItem("uuid")
+
+    try {
+
+        // 토큰 재발급 요청
+        let response = await fetch('http://localhost:8080/api/v1/auth/token', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ accessToken: token,uuid: uuid})
+        });
+        if (!response.ok){
+            alert("토큰 재발급 요청 실패")
+            window.location.href = "/login"
+        }
+
+        let data = await response.json();
+        console.log(data, "데이터")
+        localStorage.setItem('token', data.accessToken);
+
+        response = await fetch(url, {
+            headers: { 'Authorization': `Bearer ${data.accessToken}` }
+        });
+        if (!response.ok){
+            alert("토큰 재발급 요청 실패")
+            window.location.href = "/login"
+        }
+
+
+        return await response.json();
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+}
+
+window.refreshTokenIfNeeded = refreshTokenAndRetryRequest;

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -129,7 +129,8 @@
             if (response.status === 200) {
                 alert('로그인 성공');
 
-                localStorage.setItem('token', data.accessToken);
+                localStorage.setItem("token",data.accessToken);
+                localStorage.setItem("uuid",data.uuid);
                 closeModal();
                 window.location.href = "/home";
 

--- a/src/main/resources/templates/my-page.html
+++ b/src/main/resources/templates/my-page.html
@@ -83,46 +83,9 @@
                 </div>
                 <div class="m-3">
                     <h5>나의 여행 코스</h5>
-                    <div class="container">
+                    <div class="container" id="course-container">
                         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-5 row-cols-xxl-6 g-2">
 
-                            <div class="col-12 col-md-6">
-                                <div class="card">
-                                    <img src="https://via.placeholder.com/150" class="card-img-top" alt="...">
-                                    <div class="card-body">
-                                        <h5 class="card-title">Card Title 1</h5>
-                                        <p class="card-text">This is a longer card with supporting text below as a
-                                            natural lead-in to additional content. This content is a little bit
-                                            longer.</p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="col-12 col-md-6">
-                                <div class="card">
-                                    <img src="https://via.placeholder.com/150" class="card-img-top" alt="...">
-                                    <div class="card-body">
-                                        <h5 class="card-title">Card Title 1</h5>
-                                        <p class="card-text">This is a longer card with supporting text below as a
-                                            natural lead-in to additional content. This content is a little bit
-                                            longer.</p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="col-12 col-md-6">
-                                <div class="card">
-                                    <img src="https://via.placeholder.com/150" class="card-img-top" alt="...">
-                                    <div class="card-body">
-                                        <h5 class="card-title">Card Title 1</h5>
-                                        <p class="card-text">This is a longer card with supporting text below as a
-                                            natural lead-in to additional content. This content is a little bit
-                                            longer.</p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- 추가 카드는 여기에 -->
                         </div>
                         </a>
                     </div>
@@ -133,90 +96,59 @@
     <th:block th:replace="~{fragments/footer :: footer}"></th:block>
 </div>
 </body>
-
+<script th:src="@{/js/retryToken.js}"></script>
 <script>
 
-    // 토큰 재발급 요청
-    async function reissueToken() {
-        const response = await fetch('http://localhost:8080/api/v1/auth/reissue', {
-            method: 'POST',
-            headers: {
-                'Authorization': 'Bearer ' + localStorage.getItem('token'),
-                'Content-Type': 'application/json',
-            }
-
-
-        });
-        return response;
+    async function myPageProcessStart(){
+        const myPageData = await fetchMyPageData();
+        await populateTravelCards(myPageData);
     }
+    myPageProcessStart();
 
-    // 마이페이지 데이터 조회
     async function fetchMyPageData() {
-        const response = await fetch('http://localhost:8080/api/v1/auth/my', {
+        const url = 'http://localhost:8080/api/v1/auth/my'
+        const response = await fetch(url, {
             method: 'GET',
             headers: {
-                // JWT 활용을 위한 헤더
-                'Authorization': 'Bearer ' + localStorage.getItem('token'),
+                'Authorization':'Bearer ' + localStorage.getItem('token'),
                 'Content-Type': 'application/json',
             },
         });
-        return response;
-    }
 
 
-    async function myPageProcessStart() {
-        const response = await fetchMyPageData()
-        const data = await response.json();
-
-        // 조회 성공
-        if (response.status === 200) {
+        if(response.status !== 200){
+            const data = await refreshTokenAndRetryRequest(url)
             document.querySelector('.nickname').innerText = data.member.nickname;
             document.querySelector('.name').innerText = data.member.memberName;
             document.querySelector('.email').innerText = data.member.email;
-        } else {
-            // 인증정보 유효하지 않음 조회 실패
-            // 1. 헤더에 토큰 없음
-            // 2. 만료되었거나 비정상적인 토큰
-            if (localStorage.getItem('token') === null || localStorage.getItem("token") === undefined) {
-                alert('로그인 정보를 찾을 수 없습니다. 다시 로그인해주세요.');
-                location.href = '/login';
-            } else {
-                // 아래 data.code 부분은 서버에서 정의한 에러코드 입니다. 서버에서 정의한 에러코드를 확인하여 처리해주세요.
-                if (data.code === "3003") {
-
-                    // 토큰이 없는 경우
-                    if (localStorage.getItem('token') === 'undefined' || localStorage.getItem('token') === null) {
-                        alert('로그인 정보를 찾을 수 없습니다. 다시 로그인해주세요.');
-                        location.href = '/login';
-                    } else {
-                        // 로컬 스토리지에 토큰 혹은 기타 다른 값이 있기는 한 경우
-                        // 재발급 요청
-                        const token = await reissueToken();
-                        if (token.status === 200) {
-                            // 토큰 재발급 성공
-                            const data = token.json();
-                            localStorage.setItem('token', data.accessToken);
-                            console.log(data);
-                        } else {
-                            // 토큰 재발급 실패
-                            alert('로그인 정보를 찾을 수 없습니다. 다시 로그인해주세요.');
-                            location.href = '/login';
-                        }
-                    }
-                }
-            }
+            return data;
         }
+
+        const data = await response.json();
+        document.querySelector('.nickname').innerText = data.member.nickname;
+        document.querySelector('.name').innerText = data.member.memberName;
+        document.querySelector('.email').innerText = data.member.email;
+        return data
     }
 
-    myPageProcessStart();
 
-    async function populateTravelCards() {
+
+    async function populateTravelCards(data) {
         // 응답 데이터를 가져오기
-        const response = await fetchMyPageData();
-        const data = await response.json();
-
         // 카드가 추가될 컨테이너 요소를 가져오기
         const container = document.querySelector('.row-cols-xxl-6');
+
+        if(data.courseList.length <= 0){
+            const container = document.getElementById('course-container');
+            const nothingHTML = `
+            <div>
+              <p> 등록된 코스가 없어요. <br/>
+              코스를 추가 해주세요
+              </p>
+            </div>
+            `
+            container.appendChild(nothingHTML)
+        }
 
         // 각 코스에 대해 반복
         data.courseList.forEach(course => {
@@ -245,6 +177,8 @@
             // 컨테이너에 카드를 추가
             container.appendChild(card);
         });
+
+
     }
 
     // 수정 페이지로 이동하고 해당 코스의 정보를 가져와서 채워넣는 함수
@@ -252,9 +186,6 @@
         // 페이지 이동
         window.location.href = `/api-test/sample-course-update/${courseId}`;
     }
-
-    // 여행 카드를 채우는 함수를 호출
-    populateTravelCards();
 
     // 삭제 요청을 보내는 함수
     async function deleteCourse(courseId) {

--- a/src/main/resources/templates/oauth2-redirect.html
+++ b/src/main/resources/templates/oauth2-redirect.html
@@ -50,6 +50,7 @@
 
              const data = await response.json()
              localStorage.setItem("token",data.accessToken);
+             localStorage.setItem("uuid",data.uuid);
              location.href = "/home"
          } catch (e) {
              console.log(e)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 💡 작업동기
- 토큰 재발급시 토큰에 들어있는 uuid를 식별할 수 없어서 추가로 uuid를 전송할 필요가 있음
- 마이페이지에서 사용한 토큰 재발급 로직을 모듈화

### 🔑 주요 변경사항
- 토큰 재발급 로직 모듈화
- 토큰 생성시 uuid 값도 포함하여 전달

토큰 재발급 모듈 사용 가이드
```javascript
// 아래 스크립트를 사용할 html에 복붙
<script th:src="@{/js/retryToken.js}"></script>

// 아래와 같은 형태로 사용 하면 됩니다.
// url 인자에는 재요청할 url을 입력 하면 됩니다.

1. 마이페이지 조회
2. 토큰 만료 응답
3. refreshTokenAndRetryRequest("마이페이지 조회 url")
4. 재발급
5. 자동으로 마이페이지 다시 됨
const data = await refreshTokenAndRetryRequest(url)
```