### PR TITLE
fix(auth): 토큰 재발급시 타인의 uuid로 발급이 가능한 문제 수정

### DIFF
--- a/src/main/java/com/traveloper/tourfinder/auth/controller/TokenController.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/controller/TokenController.java
@@ -25,16 +25,13 @@ public class TokenController {
             @RequestBody
             ReissuanceDto dto
     ) {
-        System.out.println("인자 테스트2");
         if( dto.getAccessToken().isEmpty() || dto.getUuid().isEmpty()){
-            System.out.println("인자 테스트");
             throw new GlobalExceptionHandler(CustomGlobalErrorCode.SERVICE_UNAVAILABLE);
         }
-        // TODO: AccessToken 재발급
+
         String token = tokenService.rolling(dto).orElseThrow(
                 () -> new GlobalExceptionHandler(CustomGlobalErrorCode.TOKEN_EXPIRED)
         );
-
 
         TokenDto response = TokenDto.builder()
                 .accessToken(token)

--- a/src/main/java/com/traveloper/tourfinder/auth/service/TokenService.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/service/TokenService.java
@@ -8,6 +8,7 @@ import com.traveloper.tourfinder.common.AppConstants;
 import com.traveloper.tourfinder.common.RedisRepo;
 import com.traveloper.tourfinder.common.exception.CustomGlobalErrorCode;
 import com.traveloper.tourfinder.common.exception.GlobalExceptionHandler;
+import io.jsonwebtoken.Claims;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,7 +35,14 @@ public class TokenService {
             return Optional.empty(); // Redis에 토큰이 없다면 빈 Optional 반환
         }
 
-        System.out.println(storedRefreshToken.get() + "토큰 체크");
+
+        Claims memberUuid = jwtTokenUtils.parseClaims(storedRefreshToken.get());
+        if(!memberUuid.get("uuid").equals(dto.getUuid())){
+            throw new GlobalExceptionHandler(CustomGlobalErrorCode.AUTHENTICATION_FAILED);
+        }
+
+
+
 
         Member member = memberRepository.findMemberByUuid(dto.getUuid())
                 .orElseThrow(() -> new GlobalExceptionHandler(CustomGlobalErrorCode.NOT_FOUND_MEMBER));

--- a/src/main/java/com/traveloper/tourfinder/auth/service/TokenService.java
+++ b/src/main/java/com/traveloper/tourfinder/auth/service/TokenService.java
@@ -37,7 +37,7 @@ public class TokenService {
 
 
         Claims memberUuid = jwtTokenUtils.parseClaims(storedRefreshToken.get());
-        if(!memberUuid.get("uuid").equals(dto.getUuid())){
+        if(!memberUuid.getSubject().equals(dto.getUuid())){
             throw new GlobalExceptionHandler(CustomGlobalErrorCode.AUTHENTICATION_FAILED);
         }
 

--- a/src/main/resources/static/js/retryToken.js
+++ b/src/main/resources/static/js/retryToken.js
@@ -11,8 +11,9 @@ async function retryTokenRequest(url) {
             body: JSON.stringify({ accessToken: token,uuid: uuid})
         });
         if (!response.ok){
-            alert("토큰 재발급 요청 실패")
+            alert(data.message)
             window.location.href = "/login"
+            return
         }
 
         let data = await response.json();
@@ -23,8 +24,9 @@ async function retryTokenRequest(url) {
             headers: { 'Authorization': `Bearer ${data.accessToken}` }
         });
         if (!response.ok){
-            alert("토큰 재발급 요청 실패")
+            alert(data.message)
             window.location.href = "/login"
+            return
         }
 
 

--- a/src/main/resources/static/js/retryToken.js
+++ b/src/main/resources/static/js/retryToken.js
@@ -1,4 +1,4 @@
-async function refreshTokenAndRetryRequest(url) {
+async function retryTokenRequest(url) {
     const token = localStorage.getItem("token")
     const uuid = localStorage.getItem("uuid")
 
@@ -35,4 +35,4 @@ async function refreshTokenAndRetryRequest(url) {
     }
 }
 
-window.refreshTokenIfNeeded = refreshTokenAndRetryRequest;
+window.refreshTokenIfNeeded = retryTokenRequest;

--- a/src/main/resources/templates/my-page.html
+++ b/src/main/resources/templates/my-page.html
@@ -117,7 +117,7 @@
 
 
         if(response.status !== 200){
-            const data = await refreshTokenAndRetryRequest(url)
+            const data = await retryTokenRequest(url)
             document.querySelector('.nickname').innerText = data.member.nickname;
             document.querySelector('.name').innerText = data.member.memberName;
             document.querySelector('.email').innerText = data.member.email;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 💡 작업동기
- uuid 값을 아무거나 대입해서 토큰을 재발급 할 수 있는 문제가 있음

### 🔑 주요 변경사항
- 토큰 재발급 서비스에 방어 코드 작성
- 함수명 변경